### PR TITLE
Add Enumbler.suppress_database_warnings option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@
 
 ## Running Checks
 - Use Bundler for all commands (`bundle exec`).
-- Lint changed Ruby files with `bundle exec rspec`.
+- Run tests with `bundle exec rspec`.
+- Lint changed Ruby files with `bundle exec rubocop`.
 
 ## Commit Guidelines
 - Keep commit messages concise and descriptive.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Enumbler is a Ruby gem that provides database-backed enums for ActiveRecord: real foreign-key lookup tables that behave like `enum`s. It supports ActiveRecord/ActiveSupport >= 6.0, < 9 and Ruby >= 3.1.
+
+## Commands
+
+```bash
+bin/setup                                  # install dependencies
+bundle exec rspec                          # run all tests
+bundle exec rspec spec/enumbler_spec.rb:42 # run a single test by file:line
+bundle exec rubocop                        # lint (also runs as a lefthook pre-commit hook)
+```
+
+### Matrix testing
+
+CI tests Ruby 3.1–3.4 against Rails 6.0–8.0 using the `Gemfile.rails*` files. To reproduce locally:
+
+```bash
+BUNDLE_GEMFILE=Gemfile.rails7.2 bundle install
+BUNDLE_GEMFILE=Gemfile.rails7.2 bundle exec rspec
+```
+
+When changing dependencies, keep all `Gemfile.rails*` variants (and their lockfiles) in sync with the main `Gemfile`.
+
+### Branching & releasing
+
+Modified git flow (see README "Development"): feature branches off `develop`; releases go to `main` via `release/x.y.z` (or `hotfix/x.y.z` off `main`), then the tag is merged back into `develop`. A release is a bare version tag on `main` (no `v` prefix, e.g. `0.10.0`) matching `lib/enumbler/version.rb`; pushing the tag makes CI run the rspec matrix and publish the gem to rubygems.org.
+
+## Architecture
+
+The gem is four small files under `lib/enumbler/`, split across the two sides of the relationship:
+
+- **`lib/enumbler.rb`** (`Enumbler` module) — included in `ApplicationRecord`; gives *consuming* models `enumbled_to :color`, a `belongs_to` replacement. It defines class scopes (`House.color(:black)`), per-enum predicates (`house.black?`, `house.not_black?`, optionally prefixed), and db-free helper attributes (`house.color_label`, `color_enum`, `color_graphql_enum`).
+
+- **`lib/enumbler/enabler.rb`** (`Enumbler::Enabler`) — included in the *lookup* model (e.g. `Color`); provides the `enumble :black, 1, ...` DSL. Each call builds an `Enumble`, registers it in the class-level `@enumbles` collection, and metaprograms constants (`Color::BLACK`), class finders (`Color.black`, `Color.black(:label)`), and predicates — with conflict detection against ActiveRecord methods (modeled on `ActiveRecord::Enum`). Also holds all the `find_enumble(s)` / `ids_from_enumbler` lookup methods (in-memory, no db hit; bang variants raise `Enumbler::Error`) and `seed_the_enumbler(!)` for syncing the definitions into the database table.
+
+- **`lib/enumbler/enumble.rb`** (`Enumbler::Enumble`) — plain value object for one enum row (id, enum symbol, label, extra attributes). Equality is loose: two Enumbles are `==` if id **or** enum **or** label match (this is how duplicate definitions are caught).
+
+- **`lib/enumbler/collection.rb`** — an `Array` subclass with `method_missing` so `Color.enumbles.black` works.
+
+- **`lib/enumbler/core_ext/symbol/case_equality_operator.rb`** — patches `Symbol#===` so `case Color.black; when :black` works. It's a global core extension; be careful changing it.
+
+The label column defaults to `label` but can be remapped per-model with `enumbler_label_column_name :emotion`; internally `Enumble#label` always refers to the enumbler value regardless of the underlying column.
+
+## Tests
+
+Specs run against an in-memory SQLite database (`spec/support/establish_sqlite_connection.rb`); each spec file defines its own schema with `ActiveRecord::Schema.define` and DatabaseCleaner wraps each example in a transaction. `spec/enumbler_spec.rb` covers nearly everything and defines the shared test models (Color, House, Feeling). Rails-version-conditional behavior may need `BUNDLE_GEMFILE` runs to verify.
+
+## Style
+
+RuboCop enforces double-quoted strings, max line length 119, trailing commas in multiline literals, and `TargetRubyVersion: 3.4` — but code must still run on Ruby 3.1 (see the gemspec), so avoid 3.2+-only syntax.

--- a/README.md
+++ b/README.md
@@ -162,11 +162,54 @@ when :blue, :purple
 end
 ```
 
+## Suppressing database warnings
+
+When an `enumble` defines extra attributes, the Enumbler verifies them against the model's table at class-load time.  If the table cannot be inspected — for example, while your test databases are dropped mid-way through a `rake parallel:setup` — it prints an `[Enumbler Warning]` for every affected model rather than raising.  If those warnings are just noise in your workflow, you can suppress them:
+
+```ruby
+Enumbler.suppress_database_warnings = true
+```
+
+Or set the environment variable `ENUMBLER_SUPPRESS_DATABASE_WARNINGS` to any non-empty value — handy for wrapping database reset commands:
+
+```bash
+ENUMBLER_SUPPRESS_DATABASE_WARNINGS=1 bundle exec rake parallel:setup
+```
+
+The Ruby-level setting, when assigned, takes precedence over the environment variable.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+### Branching (modified git flow)
+
+Day-to-day work follows git flow: feature/bug/chore branches come off `develop` and are merged back into `develop` via PR. Releases move `develop` into `main` through a `release/x.y.z` branch (or a `hotfix/x.y.z` branch off `main` for urgent fixes), and after tagging, the tag is merged back into `develop` so both branches share the release commit.
+
+### Releasing a New Version
+
+A release is triggered by pushing a **version tag** to GitHub: the `CI Matrix Testing` workflow runs the rspec matrix and, if green, the `Publish Gem` job builds the gem and pushes it to [rubygems.org](https://rubygems.org).
+
+Two things to know before tagging:
+
+1. The published version comes from `lib/enumbler/version.rb`, **not** the tag name — make sure they match (the tag is bare, no `v` prefix: `0.10.0`).
+2. RubyGems rejects duplicate versions, so every release needs a version bump.
+
+Steps:
+
+1. Bump `Enumbler::VERSION` in `lib/enumbler/version.rb` (and run `bundle install` so the lockfiles pick it up) on a `release/x.y.z` branch off `develop` (or `hotfix/x.y.z` off `main`).
+2. Merge the branch into `main`, then tag the release commit:
+
+   ```bash
+   git checkout main && git pull
+   git tag -a 0.10.0 -m "Release 0.10.0"
+   git push origin main 0.10.0
+   ```
+
+3. Watch the `CI Matrix Testing` workflow on the tag: when the publish job is green, confirm the new version on [rubygems.org](https://rubygems.org/gems/enumbler).
+4. Merge the tag back into `develop`: `git checkout develop && git merge 0.10.0 && git push`.
 
 ### Matrix testing
 

--- a/lib/enumbler.rb
+++ b/lib/enumbler.rb
@@ -17,6 +17,26 @@ module Enumbler
   # An error raised by the Enumbler.
   class Error < StandardError; end
 
+  class << self
+    attr_writer :suppress_database_warnings
+
+    # Suppress the boot-time `[Enumbler Warning]` messages emitted when a
+    # model's table or attributes cannot be verified (e.g., while the database
+    # is dropped during a test database reset).  Enable by setting
+    # `Enumbler.suppress_database_warnings = true` or by setting the
+    # environment variable `ENUMBLER_SUPPRESS_DATABASE_WARNINGS` to any
+    # non-empty value.  The Ruby-level setting, when assigned, wins over the
+    # environment variable.
+    # @return [Boolean]
+    def suppress_database_warnings?
+      if @suppress_database_warnings.nil?
+        ENV["ENUMBLER_SUPPRESS_DATABASE_WARNINGS"].present?
+      else
+        @suppress_database_warnings
+      end
+    end
+  end
+
   # Include these ClassMethods in your base ApplicationRecord model to bestow
   # any of your models with the ability to be connected to an Enumbled relation
   # in the same way you would use `belongs_to` now you use `enumbled_to`.

--- a/lib/enumbler/enabler.rb
+++ b/lib/enumbler/enabler.rb
@@ -462,12 +462,16 @@ module Enumbler
         raise Enumbler::Error,
           "The model #{self} does not support the attribute(s): #{unsupported_attrs.keys.map(&:to_s).to_sentence}"
       rescue ActiveRecord::PendingMigrationError
+        return if Enumbler.suppress_database_warnings?
+
         warn "[Enumbler Warning] => The model #{self} does not currently support the attribute(s): " \
              "#{unsupported_attrs.keys.map(&:to_s).to_sentence}. " \
              "You have a pending migration which hopefully would remedy this! " \
              "If not, you need to add a migration for this attibrute or " \
              "remove it from the Enumbler."
       rescue ActiveRecord::StatementInvalid
+        return if Enumbler.suppress_database_warnings?
+
         warn "[Enumbler Warning] => Unable to find a table for #{self}." \
              "This is to be expected if there is a pending migration;  " \
              "however, if there is not then something is amiss."

--- a/spec/enumbler_spec.rb
+++ b/spec/enumbler_spec.rb
@@ -180,6 +180,34 @@ RSpec.describe Enumbler do
         expect(ModelWithoutTable).to receive(:warn).with(/pending migration/)
         ModelWithoutTable.enumble(:test, 2, bob: "ok")
       end
+
+      context "when Enumbler.suppress_database_warnings is enabled" do
+        around do |example|
+          Enumbler.suppress_database_warnings = true
+          example.run
+        ensure
+          Enumbler.suppress_database_warnings = nil
+        end
+
+        it "does not warn" do
+          expect(ModelWithoutTable).not_to receive(:warn)
+          ModelWithoutTable.enumble(:quiet, 3, bob: "ok")
+        end
+      end
+
+      context "when ENV['ENUMBLER_SUPPRESS_DATABASE_WARNINGS'] is set" do
+        around do |example|
+          ENV["ENUMBLER_SUPPRESS_DATABASE_WARNINGS"] = "1"
+          example.run
+        ensure
+          ENV.delete("ENUMBLER_SUPPRESS_DATABASE_WARNINGS")
+        end
+
+        it "does not warn" do
+          expect(ModelWithoutTable).not_to receive(:warn)
+          ModelWithoutTable.enumble(:hushed, 4, bob: "ok")
+        end
+      end
     end
 
     it "queries the collection", :seed do


### PR DESCRIPTION
## What

Adds a way to silence the boot-time `[Enumbler Warning]` messages (`Unable to find a table for ...` / `...pending migration...`) emitted by `raise_error_if_model_does_not_support_attributes` when a model's table cannot be inspected at class-load time.

- New `Enumbler.suppress_database_warnings` writer + `Enumbler.suppress_database_warnings?` predicate, which also honors `ENV["ENUMBLER_SUPPRESS_DATABASE_WARNINGS"]` (any non-empty value). The Ruby-level setting, when assigned, wins over the env var.
- Both rescue-block `warn` calls in `Enumbler::Enabler` return early when suppression is on.
- Specs for both the Ruby flag and the env var, alongside the existing default-behavior spec.
- README section documenting the option.

## Why

In apps with many enumbled models passing extra attributes (octoo-api has ~23), a test-database reset (`rake parallel:drop` + `rake parallel:setup`) boots the app while tables are missing and blasts one warning per model per parallel database. The guard itself stays — it's a legitimate catch for the migration chicken-and-egg case — it's just now opt-out for tooling that expects the tables to be absent.

## Also included

- README: documents the modified git flow branching model and the tag-triggered release process (verified against the repo's actual history and CI workflow).
- AGENTS.md: the lint instruction incorrectly said `bundle exec rspec`; now split into test (rspec) and lint (rubocop).
- New CLAUDE.md with commands/architecture notes for Claude Code.

## Testing

- `bundle exec rspec` — 57 examples, 0 failures (Ruby 3.3.11 locally; matrix runs in CI)
- `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)