### PR TITLE
Publish gem via RubyGems trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -64,22 +64,23 @@ jobs:
 
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
+    # Publishes via RubyGems trusted publishing (OIDC) — no API key, and
+    # exempt from the account's OTP requirement.  The trusted publisher on
+    # rubygems.org is registered for this repo + this workflow filename.
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.4
+        bundler-cache: true
 
-    - name: Publish to RubyGems
-      run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        gem build *.gemspec
-        gem push *.gem
-      env:
-        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+    - uses: rubygems/release-gem@v1
 


### PR DESCRIPTION
## What

Replaces the API-key `gem push` in the `Publish Gem` job with the official [`rubygems/release-gem`](https://github.com/rubygems/release-gem) action using [trusted publishing](https://guides.rubygems.org/trusted-publishing) (OIDC): job-level `id-token: write` + `contents: write` permissions, `persist-credentials: false` on checkout, `bundler-cache` for the `rake build` the action performs.

## Why

The 0.11.0 tag's Publish Gem job failed: the RubyGems account requires an OTP for API-key pushes, so the `RUBYGEMS_AUTH_TOKEN` path can never succeed in CI (and evidently never has — 0.10.0 was pushed manually). Trusted publishing is exempt from the OTP requirement and removes the long-lived secret entirely.

## Prerequisite (manual, rubygems.org)

Add a trusted publisher on the enumbler gem: owner `octoopi`, repository `enumbler`, workflow `ruby.yml`, environment blank.

## After merge

Re-point the `0.11.0` tag at the new `main` head (nothing was published, so moving the tag is safe) and push it — the tag run should then publish 0.11.0 via OIDC. Then merge the tag back into `develop`, and clean up: delete the `RUBYGEMS_AUTH_TOKEN` repo secret and revoke the API key on rubygems.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)