### PR TITLE
Fix trusted publishing: credentials action + plain gem push

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -67,8 +67,11 @@ jobs:
     # Publishes via RubyGems trusted publishing (OIDC) — no API key, and
     # exempt from the account's OTP requirement.  The trusted publisher on
     # rubygems.org is registered for this repo + this workflow filename.
+    # Uses configure-rubygems-credentials + a plain `gem push` rather than
+    # the release-gem action: that action runs `rake release`, which wants
+    # to git-push and create its own v-prefixed tag — this repo tags
+    # manually (bare version numbers) and this job runs on a detached HEAD.
     permissions:
-      contents: write
       id-token: write
 
     steps:
@@ -80,7 +83,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.4
-        bundler-cache: true
 
-    - uses: rubygems/release-gem@v1
+    - uses: rubygems/configure-rubygems-credentials@v2.1.0
+
+    - name: Build and push gem
+      run: |
+        gem build *.gemspec
+        gem push *.gem
 


### PR DESCRIPTION
## What

Follow-up to #19. The `rubygems/release-gem` action runs bundler's `rake release` task, which attempts `git push origin refs/heads/HEAD` and creates its own `v`-prefixed tag. This repo's release flow tags manually (bare version numbers, e.g. `0.11.0`) and the publish job runs on a detached HEAD from the tag checkout, so the job failed with `src refspec refs/heads/HEAD does not match any` — after the OIDC credential exchange had already succeeded.

Switch to the lower-level [`rubygems/configure-rubygems-credentials`](https://github.com/rubygems/configure-rubygems-credentials) action (exchanges the OIDC token for temporary push credentials) followed by a plain `gem build` + `gem push`, which matches the original job shape with no git operations. Also drops the now-unneeded `contents: write` permission and `bundler-cache`.

## After merge

Re-point the `0.11.0` tag at the new `main` head and push — third time's the charm. Then merge the tag back into `develop` and delete the obsolete `RUBYGEMS_AUTH_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)